### PR TITLE
Add useForm, Form, and connectByRef that allow for more succinct forms

### DIFF
--- a/components/form/Form.stories.js
+++ b/components/form/Form.stories.js
@@ -1,0 +1,50 @@
+import { TextInput, SubmitButton, Checkbox, RadioButton, Form, useForm } from '/components/form'
+import { Checkbox as ManualCheckbox } from '/components/inputs'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as y from 'yup'
+
+export default {
+  title: 'Components/Form/Form',
+  component: Form,
+  tags: ['autodocs'],
+}
+
+const wait = async (timeout) => new Promise((resolve) => setTimeout(resolve, timeout))
+
+const Template = () => {
+  const methods = useForm({
+    resolver: yupResolver(
+      y.object().shape({
+        textInput: y.string().required('Text Input is a required field'),
+      })
+    ),
+    onSubmit: async (data) => {
+      await wait(3000)
+      alert(`onSubmit: ${JSON.stringify(data)}`)
+    }
+  })
+  const data = methods.watch()
+  return <div>
+    <Form methods={methods} >
+      <TextInput name='textInput' />
+      <TextInput name='nested.nestedInputExample' />
+      <Checkbox name='automaticCheckbox' />
+      <ManualCheckbox label='Manual Checkbox' {...methods.register('manualCheckbox')} />
+      <fieldset>
+        <RadioButton name='color' value='red' />
+        <RadioButton name='color' value='green' />
+        <RadioButton name='color' value='blue' />
+      </fieldset>
+      <SubmitButton>Submit</SubmitButton>
+    </Form>
+    <div style={{padding: '1em', border: '1px solid #efefef', borderRadius: '1em', marginTop: '2em'}} >
+      <p style={{fontStyle: 'italic', fontSize: '12px'}} >Preview of the form data that will be included in onSubmit</p>
+      <pre style={{padding: '1em', backgroundColor: '#efefef', borderRadius: '0.5em'}} >
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  </div>
+}
+
+export const Default = Template.bind({})
+Default.args = {}

--- a/components/form/form/index.js
+++ b/components/form/form/index.js
@@ -1,0 +1,28 @@
+import { FormProvider } from 'react-hook-form'
+
+/**
+ * TODO: Improve the global form error
+ *
+ * This Form component should always be used with useForm found in
+ * /components/utils/use-form
+ *
+ * Look at the story code to see how it works with inputs.
+ *
+ * What this component does:
+ *
+ * - Sets the FormProvider context so that inputs inside of it 
+ *   can access things like register and form errors directly inside
+ *   of them rather than having them passed down as props. See react-hook-form
+ *   docs on FormProvider for more information.
+ * - Shows the form-level formError if there is one.
+ * - Passes along the onSubmit which is returned by /components/utils/use-form
+ *
+ */
+export const Form = ({methods, children, ...props}) =>
+  <FormProvider {...methods} >
+    <form onSubmit={methods.onSubmit} {...props} >
+      {methods.formState.errors.formError && <h4>{methods.formState.errors.formError?.message}</h4>}
+      {children}
+    </form>
+  </FormProvider>
+

--- a/components/form/index.js
+++ b/components/form/index.js
@@ -1,0 +1,5 @@
+export { Form } from './form'
+export { connectByRef } from './util/connect-by-ref'
+export { useForm } from './util/use-form'
+export { SubmitButton } from './submit-button'
+export { TextInput, Checkbox, RadioButton } from './inputs'

--- a/components/form/inputs/index.js
+++ b/components/form/inputs/index.js
@@ -1,0 +1,17 @@
+import Case from 'case'
+import { connectByRef } from '../util/connect-by-ref'
+import * as Inputs from '/components/inputs'
+
+export const TextInput = connectByRef(Inputs.TextInput)
+export const Checkbox = connectByRef(Inputs.Checkbox)
+export const RadioButton = connectByRef(
+  Inputs.RadioButton,
+  // override the default props since radio auto label should be based
+  // on the value rather than the name
+  ({name, error, props}) =>
+    ({name, error, label: Case.capital(props.value || '')})
+)
+// TODO: get these other inputs working
+// export const DatePickerSelect = connectByRef(Inputs.DatePickerSelect)
+// export const SelectInput = connectByRef(Inputs.SelectInput)
+// export const FileUpload = connectByRef(Inputs.FileUpload)

--- a/components/form/submit-button/index.js
+++ b/components/form/submit-button/index.js
@@ -1,0 +1,12 @@
+import { useFormContext } from 'react-hook-form'
+import { Button } from '/components/button'
+
+export const SubmitButton = (props) => {
+  const { formState: { isSubmitting, errors: {formError, ...errors} } } = useFormContext()
+  return <Button
+    type='submit'
+    isLoading={isSubmitting}
+    disabled={isSubmitting || Object.keys(errors).length}
+    {...props}
+  />
+}

--- a/components/form/util/connect-by-ref.js
+++ b/components/form/util/connect-by-ref.js
@@ -1,0 +1,49 @@
+import Case from 'case'
+import { useFormContext } from 'react-hook-form'
+
+/**
+ * This is a hoc that wraps a form input.
+ * Instead of passing in the props {...regsiter(name)} to
+ * the input as you normally would, you only need to pass
+ * a name prop and it should work. The input must be placed
+ * inside a parent component that is a FormProvider. Generally
+ * this will mean it must be inside of the form component
+ * found at /components/form/form
+ *
+ * Here is an example:
+ *
+ * before:
+ * <TextInput
+ *   name='email'
+ *   error={formState.errors[name]?.message}
+ *   {...register('email')}
+ * />
+ *
+ * after:
+ * <TextInput name='email' />
+ *
+ * The props builder function allows you to customize which other props
+ * get passed along to your underlying Input component.
+ * For example, if you look at defaultPropsBuilder, a default
+ * label is provided based on the name. For something like a Radio
+ * input, this doesn't make sense since multiple Radios will have the
+ * same name, so in that case you can override this function.
+ */
+export const connectByRef = (
+  Component,
+  propsBuilder = defaultPropsBuilder
+) => ({name, ...props}) => {
+  const { register, formState } = useFormContext()
+  const error = formState?.errors?.[name]
+  return <Component
+    {...propsBuilder({name, error, props})}
+    {...register(name)}
+    {...props}
+  />
+}
+
+const defaultPropsBuilder = ({name, error}) => ({
+  name,
+  error: error?.message,
+  label: Case.capital(name.split('.').slice(-1)[0])
+})

--- a/components/form/util/use-form.js
+++ b/components/form/util/use-form.js
@@ -1,0 +1,21 @@
+import { useForm as useFormBase } from 'react-hook-form'
+
+export const useForm = ({onSubmit, ...rest} = {}) => {
+  const methods = useFormBase(rest)
+  return {
+    onSubmit: methods.handleSubmit(async data => {
+      try {
+        const response = await onSubmit(data)
+        return response
+      } catch (err) {
+        const message = err.response?.data?.detail
+        if (message) {
+          methods.setError('formError', {type: 'manual', message})
+        } else {
+          console.log('TODO, handle error', err)
+        }
+      }
+    }),
+    ...methods
+  }
+}

--- a/components/inputs/checkbox/checkbox.js
+++ b/components/inputs/checkbox/checkbox.js
@@ -1,14 +1,15 @@
-import { forwardRef } from 'react'
+import { forwardRef, useMemo } from 'react'
 import { classnames } from 'util/classnames'
 import { Icon } from 'components/icon'
 import styles from './checkbox.module.scss'
 
 export const Checkbox = forwardRef(
   (
-    { id, name, value, label, icon, iconVariation = 'filled', ...props },
+    { id: givenId, name, value, label, icon, iconVariation = 'filled', ...props },
     ref
-  ) => (
-    <div
+  ) => {
+    const id = useMemo(() => givenId || `${Math.random()}`, [givenId])
+    return <div
       className={classnames(
         styles['checkbox-component'],
         icon ? styles['has-icon'] : null
@@ -30,7 +31,7 @@ export const Checkbox = forwardRef(
       ) : null}
       <label htmlFor={id}>{label}</label>
     </div>
-  )
+  }
 )
 
 Checkbox.displayName = 'Checkbox'

--- a/components/inputs/radio-button/radio-button.js
+++ b/components/inputs/radio-button/radio-button.js
@@ -1,8 +1,10 @@
+import { forwardRef, useMemo } from 'react'
 import styles from './radio-button.module.scss'
 
-export const RadioButton = ({ id, name, value, label, ...props }) => (
-  <div className={styles['radio-button-component']}>
-    <input type="radio" name={name} value={value} id={id} {...props} />
+export const RadioButton = forwardRef(({ id: givenId, name, value, label, ...props }, ref) => {
+  const id = useMemo(() => givenId || `${Math.random()}`, [givenId])
+  return <div className={styles['radio-button-component']}>
+    <input type="radio" name={name} value={value} id={id} ref={ref} {...props} />
     <label htmlFor={id}>{label}</label>
   </div>
-)
+})

--- a/components/temporary-nav/temporary-nav.js
+++ b/components/temporary-nav/temporary-nav.js
@@ -51,12 +51,7 @@ export const TemporaryNav = () => {
         {basicSessionData && !basicSessionData.isLoggedIn ? (
           <>
             <li>
-              <button
-                className="button-reset"
-                onClick={() => setModal('LoginModal')}
-              >
-                Login
-              </button>
+              <Link href="/login">Login</Link>
             </li>
             <li>
               <button

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "^5.0.0",
         "@tanstack/react-query-devtools": "^5.0.3",
         "axios": "^1.6.7",
+        "case": "^1.6.3",
         "date-fns": "^3.6.0",
         "framer-motion": "^11.1.7",
         "iron-session": "^8.0.1",
@@ -9619,6 +9620,14 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/case": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
+      "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-query-devtools": "^5.0.3",
     "axios": "^1.6.7",
+    "case": "^1.6.3",
     "date-fns": "^3.6.0",
     "framer-motion": "^11.1.7",
     "iron-session": "^8.0.1",

--- a/pages/api/session.ts
+++ b/pages/api/session.ts
@@ -29,11 +29,15 @@ export default async function handler(
       res.status(200).json({ userId: authResponse.userId })
     } catch (error: any) {
       if (error.response && error.response.status) {
-        res.status(error.response.status).json({
-          message:
-            error.response.statusText ||
-            'An error occurred during the operation.',
-        })
+        if (error.response.data) {
+          res.status(error.response.status).json(error.response.data)
+        } else {
+          res.status(error.response.status).json({
+            message:
+              error.response.statusText ||
+              'An error occurred during the operation.',
+          })
+        }
       } else {
         res.status(500).json({ message: 'Internal Server Error' })
       }

--- a/pages/login/index.js
+++ b/pages/login/index.js
@@ -1,9 +1,40 @@
-const LoginIndex = () => (
-  <>
-    <h2>Login</h2>
-    <p>You should see this page only if you're not logged in</p>
-  </>
-)
+import { useRouter } from 'next/router'
+import { loginSession } from '/hooks/session'
+import { Form, useForm, TextInput, SubmitButton } from '/components/form'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as y from 'yup'
 
-LoginIndex.Layouts = ['BaseLayout']
-export default LoginIndex
+const LoginForm = () => {
+  const router = useRouter()
+  const methods = useForm({
+    resolver: yupResolver(
+      y.object().shape({
+        email: y.string().email().required(),
+        password: y.string().required(),
+      })
+    ),
+    onSubmit: async data => { 
+      await loginSession(data)
+      router.push('/dashboard')
+    },
+  })
+  return (
+    <Form methods={methods}>
+      <TextInput name='email' type='email' />
+      <TextInput name='password' type='password' />
+      <SubmitButton>Submit</SubmitButton>
+    </Form>
+  )
+}
+
+const LoginPage = () => {
+  return (
+    <>
+      <h2>Login</h2>
+      <LoginForm />
+    </>
+  )
+}
+
+LoginPage.Layouts = ['BaseLayout']
+export default LoginPage


### PR DESCRIPTION
Looking for feedback. 

I included an example form story which I think should be helpful for onboarding.

One slightly unorthodox thing I did is included a utils folder inside of `/components/form` because they are so coupled with the form component it seemed awkward to include them globally in the /utils folder. 