### PR TITLE
Fix middleware redirecting before session loads

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -16,7 +16,9 @@ export async function middleware(request) {
   const isUnauthenticatedRoute = unauthenticatedRoutes.includes(nextUrlPathname)
   const isLoggedIn = Boolean(token)
 
-  if (isAuthenticatedRoute && !isLoggedIn) {
+  // Don't redirect if session is empty (might be loading/transitioning)
+  // Only redirect if we have a definitive session that shows user is not logged in
+  if (isAuthenticatedRoute && !isLoggedIn && Object.keys(session).length > 0) {
     return NextResponse.redirect(`${request.nextUrl.origin}/`, 302)
   }
 


### PR DESCRIPTION
- Encountered an issue on CC where we login in via a modal for freemium.

- There was no page redirect, just a modal close, and i think Middleware runs only on full page loads, so Middleware didn't have complete session data. 

I think in 99% cases we load to another page and this is not an issue.?